### PR TITLE
fix error variable name: unmarshall response body

### DIFF
--- a/coderd/oauthpki/oidcpki.go
+++ b/coderd/oauthpki/oidcpki.go
@@ -247,7 +247,7 @@ func (src *jwtTokenSource) Token() (*oauth2.Token, error) {
 	}
 
 	if unmarshalError != nil {
-		return nil, xerrors.Errorf("oauth2: cannot unmarshal token: %w", err)
+		return nil, xerrors.Errorf("oauth2: cannot unmarshal token: %w", unmarshalError)
 	}
 
 	newToken := &oauth2.Token{


### PR DESCRIPTION
Incorrect error variable is used during reporting of the issue during unmarshall operations and this makes it hard to understand the underlying reason for OIDC failure: use `unmarshalError` instead of `err`
